### PR TITLE
Included Characters into a chronicle

### DIFF
--- a/app/Enums/UserRoleEnum.php
+++ b/app/Enums/UserRoleEnum.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enums;
+
+enum UserRoleEnum: string
+{
+    case GAME_MASTER = 'game_master';
+    case PLAYER = 'player';
+}

--- a/app/Http/Controllers/CharacterController.php
+++ b/app/Http/Controllers/CharacterController.php
@@ -11,6 +11,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Storage;
 use Inertia\Inertia;
 use Inertia\Response;
@@ -26,15 +27,9 @@ class CharacterController extends Controller
         return $strategy->retrieveCharacters($user);
     }
 
-    private function isLinkedToCurrentUser(Character $character): bool
-    {
-        /** @phpstan-ignore-next-line */
-        return $character->users->contains(Auth::user()->id);
-    }
-
     public function show(Character $character): Response
     {
-        if (! $this->isLinkedToCurrentUser($character) && ! $this->userIsAdmin()) {
+        if (! Gate::allows('show-character', $character)) {
             return abort(403, 'Vous ne pouvez pas consulter ce personnage');
         }
 

--- a/app/Http/Controllers/ChronicleController.php
+++ b/app/Http/Controllers/ChronicleController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Chronicle;
+
+class ChronicleController extends Controller
+{
+    public function show(Chronicle $chronicle)
+    {
+        $characters = $chronicle->characters;
+
+        return inertia('Chronicle/Show', [
+            'characters' => $characters,
+        ]);
+    }
+}

--- a/app/Models/Character.php
+++ b/app/Models/Character.php
@@ -66,4 +66,9 @@ class Character extends Model
     {
         return $this->belongsToMany(Capacity::class);
     }
+
+    public function chronicle(): BelongsTo
+    {
+        return $this->belongsTo(Chronicle::class);
+    }
 }

--- a/app/Models/Chronicle.php
+++ b/app/Models/Chronicle.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Chronicle extends Model
 {
@@ -15,5 +16,10 @@ class Chronicle extends Model
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class, 'game_master_id');
+    }
+
+    public function characters(): HasMany
+    {
+        return $this->hasMany(Character::class);
     }
 }

--- a/app/Models/Chronicle.php
+++ b/app/Models/Chronicle.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Chronicle extends Model
+{
+    use HasFactory;
+
+    protected $guarded = [];
+}

--- a/app/Models/Chronicle.php
+++ b/app/Models/Chronicle.php
@@ -4,10 +4,16 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class Chronicle extends Model
 {
     use HasFactory;
 
     protected $guarded = [];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'game_master_id');
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -5,6 +5,7 @@ namespace App\Models;
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
@@ -46,5 +47,10 @@ class User extends Authenticatable
     public function characters(): BelongsToMany
     {
         return $this->belongsToMany(Character::class);
+    }
+
+    public function chronicles(): HasMany
+    {
+        return $this->hasMany(Chronicle::class, 'game_master_id');
     }
 }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -2,8 +2,11 @@
 
 namespace App\Providers;
 
-// use Illuminate\Support\Facades\Gate;
+use App\Enums\UserRoleEnum;
+use App\Models\Character;
+use App\Models\User;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Gate;
 
 class AuthServiceProvider extends ServiceProvider
 {
@@ -25,6 +28,8 @@ class AuthServiceProvider extends ServiceProvider
     {
         $this->registerPolicies();
 
-        //
+        Gate::define('show-character', function(User $user, Character $character) {
+            return $character->users->contains($user->id) || $user->role === UserRoleEnum::GAME_MASTER->value;
+        });
     }
 }

--- a/app/Strategies/Character/FetchCharacterInterface.php
+++ b/app/Strategies/Character/FetchCharacterInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Strategies\Character;
+
+use Illuminate\Contracts\Auth\Authenticatable;
+
+interface FetchCharacterInterface
+{
+    public function retrieveCharacters(Authenticatable $user);
+}

--- a/app/Strategies/Character/FetchStrategyFactory.php
+++ b/app/Strategies/Character/FetchStrategyFactory.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Strategies\Character;
+
+use Illuminate\Contracts\Auth\Authenticatable;
+
+class FetchStrategyFactory
+{
+    public static function create(Authenticatable $user): FetchCharacterInterface
+    {
+        if ($user->role === 'game_master') {
+            return new GameMasterFetchCharacterStrategy();
+        }
+
+        return new PlayerFetchCharacterStrategy();
+    }
+}

--- a/app/Strategies/Character/FetchStrategyFactory.php
+++ b/app/Strategies/Character/FetchStrategyFactory.php
@@ -2,13 +2,14 @@
 
 namespace App\Strategies\Character;
 
+use App\Enums\UserRoleEnum;
 use Illuminate\Contracts\Auth\Authenticatable;
 
 class FetchStrategyFactory
 {
     public static function create(Authenticatable $user): FetchCharacterInterface
     {
-        if ($user->role === 'game_master') {
+        if ($user->role === UserRoleEnum::GAME_MASTER->value) {
             return new GameMasterFetchCharacterStrategy();
         }
 

--- a/app/Strategies/Character/GameMasterFetchCharacterStrategy.php
+++ b/app/Strategies/Character/GameMasterFetchCharacterStrategy.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Strategies\Character;
+
+use Illuminate\Contracts\Auth\Authenticatable;
+use Inertia\Inertia;
+
+class GameMasterFetchCharacterStrategy implements FetchCharacterInterface
+{
+    public function retrieveCharacters(Authenticatable $user)
+    {
+        $chronicles = $user->chronicles;
+
+        return Inertia::render('Chronicle/Index', [
+            'chronicles' => $chronicles,
+        ]);
+    }
+}

--- a/app/Strategies/Character/PlayerFetchCharacterStrategy.php
+++ b/app/Strategies/Character/PlayerFetchCharacterStrategy.php
@@ -11,11 +11,11 @@ class PlayerFetchCharacterStrategy implements FetchCharacterInterface
 {
     public function retrieveCharacters(Authenticatable $user)
     {
-        //        if ($this->playerHasOnlyOneCharacter($user)) {
-        //            $character = $user->characters->first();
-        //
-        //            return to_route('characters.show', $character);
-        //        }
+        if ($this->playerHasOnlyOneCharacter($user)) {
+            $character = $user->characters->first();
+
+            return to_route('characters.show', $character);
+        }
 
         return $this->fetchChronicles($user);
     }

--- a/app/Strategies/Character/PlayerFetchCharacterStrategy.php
+++ b/app/Strategies/Character/PlayerFetchCharacterStrategy.php
@@ -2,6 +2,7 @@
 
 namespace App\Strategies\Character;
 
+use App\Models\Character;
 use App\Models\Chronicle;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Inertia\Inertia;
@@ -10,13 +11,13 @@ class PlayerFetchCharacterStrategy implements FetchCharacterInterface
 {
     public function retrieveCharacters(Authenticatable $user)
     {
-        if ($this->playerHasOnlyOneCharacter($user)) {
-            $character = $user->characters->first();
+        //        if ($this->playerHasOnlyOneCharacter($user)) {
+        //            $character = $user->characters->first();
+        //
+        //            return to_route('characters.show', $character);
+        //        }
 
-            return to_route('characters.show', $character);
-        }
-
-        $this->fetchChronicles($user);
+        return $this->fetchChronicles($user);
     }
 
     private function playerHasOnlyOneCharacter(Authenticatable $user)
@@ -28,7 +29,9 @@ class PlayerFetchCharacterStrategy implements FetchCharacterInterface
     {
         $chronicles = Chronicle::query()
             ->whereHas('characters', function($query) use ($user) {
-                $query->where('user_id', $user->id);
+                $query->whereHas('users', function($query) use ($user) {
+                    $query->where('character_user.user_id', $user->id);
+                });
             })
             ->get();
 

--- a/app/Strategies/Character/PlayerFetchCharacterStrategy.php
+++ b/app/Strategies/Character/PlayerFetchCharacterStrategy.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Strategies\Character;
+
+use App\Models\Chronicle;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Inertia\Inertia;
+
+class PlayerFetchCharacterStrategy implements FetchCharacterInterface
+{
+    public function retrieveCharacters(Authenticatable $user)
+    {
+        if ($this->playerHasOnlyOneCharacter($user)) {
+            $character = $user->characters->first();
+
+            return to_route('characters.show', $character);
+        }
+
+        $this->fetchChronicles($user);
+    }
+
+    private function playerHasOnlyOneCharacter(Authenticatable $user)
+    {
+        return $user->characters->count() === 1;
+    }
+
+    private function fetchChronicles(Authenticatable $user)
+    {
+        $chronicles = Chronicle::query()
+            ->whereHas('characters', function($query) use ($user) {
+                $query->where('user_id', $user->id);
+            })
+            ->get();
+
+        return Inertia::render('Chronicle/Index', [
+            'chronicles' => $chronicles,
+        ]);
+    }
+}

--- a/database/factories/ChronicleFactory.php
+++ b/database/factories/ChronicleFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Chronicle>
+ */
+class ChronicleFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition()
+    {
+        return [
+            'name'        => fake()->name(),
+            'universe'    => fake()->word(),
+            'description' => fake()->text(),
+        ];
+    }
+}

--- a/database/factories/ChronicleFactory.php
+++ b/database/factories/ChronicleFactory.php
@@ -17,7 +17,7 @@ class ChronicleFactory extends Factory
     public function definition()
     {
         return [
-            'name'        => fake()->name(),
+            'name'        => fake()->words(3, true),
             'universe'    => fake()->word(),
             'description' => fake()->text(),
         ];

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Enums\UserRoleEnum;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
 
@@ -20,7 +21,7 @@ class UserFactory extends Factory
         return [
             'name'              => fake()->name(),
             'email'             => fake()->unique()->safeEmail(),
-            'role'              => 'game_master',
+            'role'              => UserRoleEnum::GAME_MASTER->value,
             'email_verified_at' => now(),
             'password'          => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
             'remember_token'    => Str::random(10),

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -20,6 +20,7 @@ class UserFactory extends Factory
         return [
             'name'              => fake()->name(),
             'email'             => fake()->unique()->safeEmail(),
+            'role'              => 'game_master',
             'email_verified_at' => now(),
             'password'          => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
             'remember_token'    => Str::random(10),

--- a/database/migrations/2025_04_29_071052_create_chronicles_table.php
+++ b/database/migrations/2025_04_29_071052_create_chronicles_table.php
@@ -17,8 +17,8 @@ return new class extends Migration {
             $table->integer('game_master_id')->unsigned();
             $table->foreign('game_master_id')->references('id')->on('users');
             $table->string('name', 100);
-            $table->string('universe', 100);
             $table->text('description');
+            $table->string('universe', 100)->nullable();
             $table->timestamps();
         });
     }

--- a/database/migrations/2025_04_29_071052_create_chronicles_table.php
+++ b/database/migrations/2025_04_29_071052_create_chronicles_table.php
@@ -14,10 +14,11 @@ return new class extends Migration {
     {
         Schema::create('chronicles', function(Blueprint $table) {
             $table->id();
-            $table->string('name', 100);
-            $table->string('universe', 100);
             $table->integer('game_master_id')->unsigned();
             $table->foreign('game_master_id')->references('id')->on('users');
+            $table->string('name', 100);
+            $table->string('universe', 100);
+            $table->text('description');
             $table->timestamps();
         });
     }

--- a/database/migrations/2025_04_29_071052_create_chronicles_table.php
+++ b/database/migrations/2025_04_29_071052_create_chronicles_table.php
@@ -14,8 +14,7 @@ return new class extends Migration {
     {
         Schema::create('chronicles', function(Blueprint $table) {
             $table->id();
-            $table->integer('game_master_id')->unsigned();
-            $table->foreign('game_master_id')->references('id')->on('users');
+            $table->foreignId('game_master_id');
             $table->string('name', 100);
             $table->text('description');
             $table->string('universe', 100)->nullable();

--- a/database/migrations/2025_04_29_071052_create_chronicles_table.php
+++ b/database/migrations/2025_04_29_071052_create_chronicles_table.php
@@ -16,6 +16,7 @@ return new class extends Migration {
             $table->id();
             $table->string('name', 100);
             $table->string('universe', 100);
+            $table->integer('game_master_id')->unsigned();
             $table->foreign('game_master_id')->references('id')->on('users');
             $table->timestamps();
         });

--- a/database/migrations/2025_04_29_071052_create_chronicles_table.php
+++ b/database/migrations/2025_04_29_071052_create_chronicles_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('chronicles', function(Blueprint $table) {
+            $table->id();
+            $table->string('name', 100);
+            $table->string('universe', 100);
+            $table->foreign('game_master_id')->references('id')->on('users');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('chronicles');
+    }
+};

--- a/database/migrations/2025_04_29_071507_add_role_column_into_users_table.php
+++ b/database/migrations/2025_04_29_071507_add_role_column_into_users_table.php
@@ -1,0 +1,19 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function(Blueprint $table) {
+            $table->string('role')->after('name')->default('player');
+        });
+    }
+};

--- a/database/migrations/2025_04_29_071725_add_chronicle_id_column_into_characters_table.php
+++ b/database/migrations/2025_04_29_071725_add_chronicle_id_column_into_characters_table.php
@@ -13,7 +13,7 @@ return new class extends Migration {
     public function up()
     {
         Schema::table('characters', function(Blueprint $table) {
-            $table->foreignId('chronicle_id')->constrained();
+            $table->unsignedBigInteger('chronicle_id')->after('height');
         });
     }
 };

--- a/database/migrations/2025_04_29_071725_add_chronicle_id_column_into_characters_table.php
+++ b/database/migrations/2025_04_29_071725_add_chronicle_id_column_into_characters_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('characters', function (Blueprint $table) {
+            $table->foreign('chronicle_id')->references('id')->on('chronicles');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('characters', function (Blueprint $table) {
+            //
+        });
+    }
+};

--- a/database/migrations/2025_04_29_071725_add_chronicle_id_column_into_characters_table.php
+++ b/database/migrations/2025_04_29_071725_add_chronicle_id_column_into_characters_table.php
@@ -13,8 +13,7 @@ return new class extends Migration {
     public function up()
     {
         Schema::table('characters', function(Blueprint $table) {
-            $table->unsignedInteger('chronicle_id')->after('height');
-            $table->foreign('chronicle_id')->references('id')->on('chronicles');
+            $table->foreignId('game_master_id')->after('height');
         });
     }
 };

--- a/database/migrations/2025_04_29_071725_add_chronicle_id_column_into_characters_table.php
+++ b/database/migrations/2025_04_29_071725_add_chronicle_id_column_into_characters_table.php
@@ -13,7 +13,7 @@ return new class extends Migration {
     public function up()
     {
         Schema::table('characters', function(Blueprint $table) {
-            $table->foreignId('game_master_id')->after('height');
+            $table->foreignId('chronicle_id')->after('height')->constrained();
         });
     }
 };

--- a/database/migrations/2025_04_29_071725_add_chronicle_id_column_into_characters_table.php
+++ b/database/migrations/2025_04_29_071725_add_chronicle_id_column_into_characters_table.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class extends Migration {
     /**
      * Run the migrations.
      *
@@ -13,20 +12,9 @@ return new class extends Migration
      */
     public function up()
     {
-        Schema::table('characters', function (Blueprint $table) {
+        Schema::table('characters', function(Blueprint $table) {
+            $table->unsignedInteger('chronicle_id')->after('height');
             $table->foreign('chronicle_id')->references('id')->on('chronicles');
-        });
-    }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('characters', function (Blueprint $table) {
-            //
         });
     }
 };

--- a/database/migrations/2025_04_29_071725_add_chronicle_id_column_into_characters_table.php
+++ b/database/migrations/2025_04_29_071725_add_chronicle_id_column_into_characters_table.php
@@ -13,7 +13,7 @@ return new class extends Migration {
     public function up()
     {
         Schema::table('characters', function(Blueprint $table) {
-            $table->foreignId('chronicle_id')->after('height')->constrained();
+            $table->foreignId('chronicle_id')->constrained();
         });
     }
 };

--- a/database/seeders/ChronicleSeeder.php
+++ b/database/seeders/ChronicleSeeder.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Chronicle;
+use App\Models\User;
+use Illuminate\Database\Seeder;
+
+class ChronicleSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $user = User::first();
+
+        Chronicle::factory()->for($user)->create();
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -5,6 +5,7 @@ namespace Database\Seeders;
 use App\Models\Attribute;
 use App\Models\Capacity;
 use App\Models\Character;
+use App\Models\Chronicle;
 use App\Models\User;
 use App\Models\Weapon;
 use Illuminate\Database\Seeder;
@@ -35,7 +36,8 @@ class DatabaseSeeder extends Seeder
         $this->call(WeaponSeeder::class);
 
         // Character creation
-        $character = Character::factory()->create();
+        $chronicle = Chronicle::first();
+        $character = Character::factory()->for($chronicle)->create();
 
         /**
          * Associate the character with user, weapon

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -26,6 +26,7 @@ class DatabaseSeeder extends Seeder
             'admin' => true,
         ]);
 
+        $this->call(ChronicleSeeder::class);
         $this->call(FamilySeeder::class);
         $this->call(CharacterWaySeeder::class);
         $this->call(ProfileSeeder::class);

--- a/resources/js/Components/Character.vue
+++ b/resources/js/Components/Character.vue
@@ -4,14 +4,25 @@ defineProps({
 })
 </script>
 <template>
-    <div class="rounded-lg p-4 bg-slate-400 w-[90%] mx-auto drop-shadow-2xl">
+    <div class="rounded-lg p-4 bg-slate-400 w-[60%] mx-auto drop-shadow-2xl">
         <div class="flex justify-center items-center w-[80%] mx-auto">
-            <img v-if="character.gender == 'M'" src="/img/directeur.png"  class="mr-4" width="55">
-            <img v-else src="/img/femme.png" class="mr-4" width="55">
-            <h1 class="text-white text-xl font-bold">{{ character.name }}</h1>
+            <img
+                v-if="character.gender === 'M'"
+                src="/img/directeur.png"
+                class="mr-4 w-24"
+                alt="male_emoji"
+            >
+            <img
+                v-else
+                src="/img/femme.png"
+                class="mr-4 w-24"
+                alt="male_emoji"
+            >
+
+            <h1 class="text-white text-2xl font-extrabold">{{ character.name }}</h1>
         </div>
         <div class="flex justify-center">
-            <button class="mt-4 p-2 rounded-lg w-[70%] bg-white font-bold text-lg drop-shadow-lg">
+            <button class="mt-4 p-2 rounded-lg w-full bg-white font-bold text-lg drop-shadow-lg">
                 <a :href="route('characters.show', character.id)">Consulter</a>
             </button>
         </div>

--- a/resources/js/Components/Chronicle.vue
+++ b/resources/js/Components/Chronicle.vue
@@ -1,5 +1,5 @@
 <script setup>
-    import SecondaryButton from "@/Components/SecondaryButton.vue";
+    import PrimaryButton from "@/Components/PrimaryButton.vue";
 
     defineProps({
         chronicle: Object,
@@ -7,14 +7,14 @@
 </script>
 <template>
     <div class="flex flex-col items-center rounded-lg py-4 px-8 bg-slate-400 w-full mx-auto drop-shadow-2xl">
-        <h1 class="text-center text-white text-2xl font-bold my-4">{{ chronicle.name }}</h1>
+        <h1 class="text-center text-white text-2xl font-extrabold my-4">{{ chronicle.name }}</h1>
 
-        <p class="text-white text-xl font-bold">{{ chronicle.description }}</p>
+        <p class="text-white text-lg">{{ chronicle.description }}</p>
 
-        <secondary-button class="mt-4">
+        <primary-button class="mt-4">
             <a :href="`/chronicles/${chronicle.id}`">
                 Selectionner
             </a>
-        </secondary-button>
+        </primary-button>
     </div>
 </template>

--- a/resources/js/Components/Chronicle.vue
+++ b/resources/js/Components/Chronicle.vue
@@ -12,7 +12,7 @@
         <p class="text-white text-xl font-bold">{{ chronicle.description }}</p>
 
         <secondary-button class="mt-4">
-            <a :href="`/chronicle/${chronicle.id}`">
+            <a :href="`/chronicles/${chronicle.id}`">
                 Selectionner
             </a>
         </secondary-button>

--- a/resources/js/Components/Chronicle.vue
+++ b/resources/js/Components/Chronicle.vue
@@ -1,0 +1,20 @@
+<script setup>
+    import SecondaryButton from "@/Components/SecondaryButton.vue";
+
+    defineProps({
+        chronicle: Object,
+    })
+</script>
+<template>
+    <div class="flex flex-col items-center rounded-lg py-4 px-8 bg-slate-400 w-full mx-auto drop-shadow-2xl">
+        <h1 class="text-center text-white text-2xl font-bold my-4">{{ chronicle.name }}</h1>
+
+        <p class="text-white text-xl font-bold">{{ chronicle.description }}</p>
+
+        <secondary-button class="mt-4">
+            <a :href="`/chronicle/${chronicle.id}`">
+                Selectionner
+            </a>
+        </secondary-button>
+    </div>
+</template>

--- a/resources/js/Pages/Chronicle/Index.vue
+++ b/resources/js/Pages/Chronicle/Index.vue
@@ -1,0 +1,29 @@
+<script setup>
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
+import { Head } from '@inertiajs/vue3';
+import Chronicle from "@/Components/Chronicle.vue";
+
+defineProps({
+    chronicles: Array,
+})
+</script>
+
+<template>
+    <Head title="Chroniques" />
+
+    <AuthenticatedLayout>
+        <template #header>
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">Chroniques</h2>
+        </template>
+
+        <div class="py-6 max-w-2xl mx-auto sm:w-full">
+            <Chronicle
+                class="mb-4"
+                v-for="chronicle in chronicles"
+                :key="chronicle.id"
+                :chronicle="chronicle"
+            />
+        </div>
+
+    </AuthenticatedLayout>
+</template>

--- a/resources/js/Pages/Chronicle/Show.vue
+++ b/resources/js/Pages/Chronicle/Show.vue
@@ -1,0 +1,29 @@
+<script setup>
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
+import { Head } from '@inertiajs/vue3';
+import Character from "@/Components/Character.vue";
+
+defineProps({
+    characters: Array,
+})
+</script>
+
+<template>
+    <Head title="Personnages" />
+
+    <AuthenticatedLayout>
+        <template #header>
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">Personnages</h2>
+        </template>
+
+        <div class="py-6 max-w-2xl mx-auto sm:w-full">
+            <Character
+                class="mb-4"
+                v-for="character in characters"
+                :key="character.id"
+                :character="character"
+            />
+        </div>
+
+    </AuthenticatedLayout>
+</template>

--- a/routes/web.php
+++ b/routes/web.php
@@ -57,7 +57,6 @@ Route::middleware('auth')->group(function() {
         Route::get('profiles/{family}/index', [CharacterProfileController::class, 'indexByFamily']);
         Route::get('profiles/{profile}/character_ways', [CharacterProfileController::class, 'getCharacterWays']);
 
-        Route::get('chronicles', [ChronicleController::class, 'index'])->name('chronicle.index');
         Route::get('chronicles/{chronicle}', [ChronicleController::class, 'show'])->name('chronicle.show');
     });
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\CharacterController;
 use App\Http\Controllers\CharacterCreateController;
 use App\Http\Controllers\CharacterProfileController;
 use App\Http\Controllers\CharacterWayController;
+use App\Http\Controllers\ChronicleController;
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\WeaponController;
 use Illuminate\Foundation\Application;
@@ -55,6 +56,9 @@ Route::middleware('auth')->group(function() {
         Route::get('advantages/{family}/index', [AdvantageController::class, 'indexByFamily']);
         Route::get('profiles/{family}/index', [CharacterProfileController::class, 'indexByFamily']);
         Route::get('profiles/{profile}/character_ways', [CharacterProfileController::class, 'getCharacterWays']);
+
+        Route::get('chronicles', [ChronicleController::class, 'index'])->name('chronicle.index');
+        Route::get('chronicles/{chronicle}', [ChronicleController::class, 'show'])->name('chronicle.show');
     });
 });
 


### PR DESCRIPTION
From now each character will be associated to a chronicle.

- It allows to group characters by chronicle
- Easier for a game master to manage character if he manages many universes
- Each chronicle can be a different universe
- Display characters according to the user role. For game_master, get his chronicles and fetch the characters of each chronicle
- For user with player role, with only one character, redirect to this character
- For user with player role with many characters, fetch the chronicles and get the characters associated to the choosed chronicle.
- Update character card component styles
- Add a gate to check if character belongs to current user

## Actions to make before deploy
- [x] Update the database to include new foreign keys
- [x] Update the check to show a character for `game_master` role
- [x] FInish the design of the chronicles cards